### PR TITLE
Tidy up config example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -6,7 +6,7 @@ groups:
     # You can include a name, if omitted it will be the key
     # used for the group
     name: "Our Product"
- 
+
     environments:
       production:
         # As with a group, giving an environment a name is options
@@ -17,33 +17,32 @@ groups:
           # Configures the rate at which Blinken will poll the alerts
           # software for hosts and alerts
           poll-ms: 10000
-    
+
           # You can provide query-parameters for use when requesting
           # alerts or hosts, which with icinga can be useful for limiting
-          # what you receive. An example is:
-          #
-          # Translates to:
-          # Host Status Types:      All
-          # Host Properties:        Not In Scheduled Downtime
-          #                         And Has Not Been Acknowledged
-          #                         And In Hard State
-          # Service Status Types:   All problems
-          # Service Properties:     Not In Scheduled Downtime
-          #                         And Has Not Been Acknowledged
-          #                         And Notifications Enabled
-          #                         And In Hard State
+          # what you receive. Docs: http://docs.icinga.org/latest/en/cgiparams.html
           alerts:
             query-params:
+              # Host Status Types: All
+              host: all
+              # Host Properties: Not In Scheduled Downtime
+              #                  And Has Not Been Acknowledged
+              #                  And In Hard State
               hostprops: 262154
-              serviceprops: 270346
+              # Service Status Types: All problems
               servicestatustypes: 28
-    
+              # Service Properties: Not In Scheduled Downtime
+              #                     And Has Not Been Acknowledged
+              #                     And Notifications Enabled
+              #                     And In Hard State
+              serviceprops: 270346
+
           # You can provide options to be passed through to the underlying
           # http client (http://http-kit.org/client.html#options)
           http:
             insecure?: true
             basic-auth: ['prod', 'secure']
-        
+
   ci:
     environments:
       main:
@@ -53,4 +52,4 @@ groups:
           poll-ms: 10000
           http:
             insecure?: true
-    
+


### PR DESCRIPTION
I found the section on the query params hard to mentally parse. At first
I thought there was a missing example, then I realised it referred to
the section below.
- Added a link to the Icinga query params docs
- Reorganised comments above the line to which they refer
- Added a host param to match the existing comment line
- Removed the whitespace only lines
