### PR TITLE
Allow blinken to be built as an uberjar

### DIFF
--- a/src/govuk/blinken.clj
+++ b/src/govuk/blinken.clj
@@ -8,7 +8,8 @@
             [clj-yaml.core :as yaml]
             [org.httpkit.server :as httpkit]
             [govuk.blinken.service :as service]
-            [govuk.blinken.routes :as routes]))
+            [govuk.blinken.routes :as routes])
+  (:gen-class :main true))
 
 
 (def type-to-worker-fn {"icinga" icinga/create


### PR DESCRIPTION
Add the :gen-class thing to govuk.blinken, so that `lein uberjar` will
generate a runnable jar file.

The intention is that we can then package up versioned .jars and upload them as [github releases](https://github.com/blog/1547-release-your-software).  This way we can have versioned artefacts, and also run blinken on machines which don't have leiningen installed.

To run an uberjar, just run `java -jar /path/to/blinken.jar /path/to/config.yml`.
