### PR TITLE
Allow filtering of sensu events and add test for filtering these events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+*.log
+*.iml
+*.pid
+.idea

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,6 +21,9 @@ groups:
           # You can provide query-parameters for use when requesting
           # alerts or hosts, which with icinga can be useful for limiting
           # what you receive. Docs: http://docs.icinga.org/latest/en/cgiparams.html
+          # You can provide filter-params to use for filtering sensu alerts after getting them.
+          # The value of this is unlike icinga, sensu does not allow us to filter what events
+          # want. So we need to filter them after we get them.
           alerts:
             query-params:
               # Host Status Types: All
@@ -36,6 +39,9 @@ groups:
               #                     And Notifications Enabled
               #                     And In Hard State
               serviceprops: 270346
+            filter-params:
+              #Only get events which match the regex pattern specified for client
+              client: .*integration.*
 
           # You can provide options to be passed through to the underlying
           # http client (http://http-kit.org/client.html#options)

--- a/test/govuk/blinken/service/sensu_test.clj
+++ b/test/govuk/blinken/service/sensu_test.clj
@@ -19,13 +19,23 @@
 
 (deftest test-parse-alerts
   (testing "converts alerts to simple map"
-    (is (= (sensu/parse-alerts example-alerts-json)
+    (is (= (sensu/parse-alerts {} example-alerts-json)
            {:critical [{:host "backend-app-1.localdomain"
                         :name "backdrop_buckets_health_check"
                         :info "CheckHTTP CRITICAL: 500\n"}
                        {:host "backend-app-2.localdomain"
                         :name "backdrop_buckets_health_check"
                         :info "CheckHTTP CRITICAL: 500\n"}]
+            :warning  [{:host "monitoring-1.localdomain"
+                        :name "check_low_disk_space_monitoring-1"
+                        :info "CheckGraphiteData WARNING: check_low_disk_space_monitoring-1 has passed warning threshold (2830925824.0)\n"}]
+            :ok       []
+            :unknown  []}))))
+
+(deftest test-filter-alerts
+  (testing "filters relevant alerts"
+    (is (= (sensu/parse-alerts {:client ".*monitoring.*"} example-alerts-json)
+           {:critical []
             :warning  [{:host "monitoring-1.localdomain"
                         :name "check_low_disk_space_monitoring-1"
                         :info "CheckGraphiteData WARNING: check_low_disk_space_monitoring-1 has passed warning threshold (2830925824.0)\n"}]


### PR DESCRIPTION
Sensu does now have the ability to filter events based on query params. So we need a way to filter what sensu events we want in blinken. This PR attempts to do it by having a new config entry simillar to how the query params are specified where we can specify how to filter the events returned. This is currently only implemented for sensu as for icinga the query params could be used to achieve the same thing.
