### PR TITLE
Make blinken compatible with sensu 0.13+

### DIFF
--- a/src/govuk/blinken.clj
+++ b/src/govuk/blinken.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging :as log]
             [govuk.blinken.service.icinga :as icinga]
             [govuk.blinken.service.sensu :as sensu]
+            [govuk.blinken.service.sensu0_13 :as sensu0_13]
             [clj-yaml.core :as yaml]
             [org.httpkit.server :as httpkit]
             [govuk.blinken.service :as service]
@@ -13,7 +14,8 @@
 
 
 (def type-to-worker-fn {"icinga" icinga/create
-                        "sensu" sensu/create})
+                        "sensu" sensu/create
+                        "sensu0_13" sensu0_13/create})
 
 (defn- create-environments [environments-config type-to-worker-fn]
   (reduce (fn [environments [key config]]

--- a/src/govuk/blinken/service/sensu0_13.clj
+++ b/src/govuk/blinken/service/sensu0_13.clj
@@ -1,0 +1,42 @@
+(ns govuk.blinken.service.sensu0_13
+  (:require [govuk.blinken.service.polling :as polling]))
+
+
+
+(defn parse-hosts [hosts-json] hosts-json
+  {:up (map :name hosts-json)
+   :down []})
+
+
+
+(def status-to-type {0 :ok 1 :warning 2 :critical 3 :unknown})
+
+(defn- parse-alert [alerts alert]
+  (let [status-keyword (status-to-type (:status (:check alert)))
+        current-list (alerts status-keyword)]
+    (assoc alerts status-keyword (conj current-list
+                                       {:host (:name (:client alert))
+                                        :name (:name (:check alert))
+                                        :info (:output (:check alert))}))))
+
+
+(defn matches-filter-param? [filter-params alert key]
+  (re-matches (re-pattern (filter-params key)) (alert key)))
+
+(defn matches-filter-params? [filter-params alert]
+  (every? (partial matches-filter-param? filter-params alert) (keys filter-params)))
+
+(defn filter-alerts [filter-params alerts]
+  (filter #(matches-filter-params? filter-params %) alerts))
+
+(defn parse-alerts [filter-params, alerts-json]
+  (reduce parse-alert
+          {:critical [] :warning [] :ok [] :unknown []}
+          (filter-alerts filter-params alerts-json)))
+
+(defn create [url options]
+  (let [filter-params (-> options :alerts :filter-params)]
+    (polling/create url {:alerts {:resource "/events"
+                                  :parse-fn (partial parse-alerts filter-params)}
+                         :hosts {:resource "/clients"
+                                 :parse-fn parse-hosts}} options)))


### PR DESCRIPTION
Some non-backward compatible changes have been introduced in [sensu 0.13](https://github.com/sensu/sensu/blob/master/CHANGELOG.md#non-backwards-compatible-changes).

Specifically, the sensu APIs are returning JSON event data incompatible with the sensu blinken parser. Since the events cannot be parsed, the blinken dashboard will not display them, giving the false illusion that all the checks are passing.

This PR adds a _sensu0_13_ profile which parses the new JSON event data. Blinken users will be able to select this profile in their configuration file instead of _sensu_.

The changes have been tested with sensu 0.16.
