### PR TITLE
Follow clojure namespace naming conventions

### DIFF
--- a/src/govuk/blinken.clj
+++ b/src/govuk/blinken.clj
@@ -5,7 +5,7 @@
             [clojure.tools.logging :as log]
             [govuk.blinken.service.icinga :as icinga]
             [govuk.blinken.service.sensu :as sensu]
-            [govuk.blinken.service.sensu0_13 :as sensu0_13]
+            [govuk.blinken.service.sensu0-13 :as sensu0-13]
             [clj-yaml.core :as yaml]
             [org.httpkit.server :as httpkit]
             [govuk.blinken.service :as service]
@@ -15,7 +15,7 @@
 
 (def type-to-worker-fn {"icinga" icinga/create
                         "sensu" sensu/create
-                        "sensu0_13" sensu0_13/create})
+                        "sensu0_13" sensu0-13/create})
 
 (defn- create-environments [environments-config type-to-worker-fn]
   (reduce (fn [environments [key config]]

--- a/src/govuk/blinken/service/sensu0_13.clj
+++ b/src/govuk/blinken/service/sensu0_13.clj
@@ -1,4 +1,4 @@
-(ns govuk.blinken.service.sensu0_13
+(ns govuk.blinken.service.sensu0-13
   (:require [govuk.blinken.service.polling :as polling]))
 
 


### PR DESCRIPTION
Fixes the contribution from #20 to follow the normal convention of using
dashes rather than underscores in namespace names.

Hyphens are preferred to underscores in namespace names (although the
filenames on disk must use underscores, due to [JVM limitations](http://stackoverflow.com/questions/4420944/why-does-clojure-convert-dashes-in-names-to-underscores-in-the-filesystem)).

I've only checked this continues to compile, not actually tested it
against a running server.
