### PR TITLE
Extract the inlined matches-filter-params? function

### DIFF
--- a/src/govuk/blinken/service/sensu.clj
+++ b/src/govuk/blinken/service/sensu.clj
@@ -19,19 +19,18 @@
                                         :name (:name (:check alert))
                                         :info (:output (:check alert))}))))
 
+(defn matches-filter-params?
+  ([filter-params alert]
+     (every? (partial matches-filter-params? filter-params alert) (keys filter-params)))
+  ([filter-params alert key]
+     (let [filter-param (filter-params key)
+           alert        (alert key)]
+       (if (map? filter-param)
+         (matches-filter-params? filter-param alert)
+         (re-matches (re-pattern filter-param) (str alert))))))
 
 (defn filter-alerts [filter-params alerts]
-  (letfn [(matches-filter-param? [filter-params alert key]
-            (let [filter-param (filter-params key)
-                  alert        (alert key)]
-              (if (map? filter-param)
-                (matches-filter-params? filter-param alert)
-                (re-matches (re-pattern filter-param) (str alert)))))
-          (matches-filter-params? [filter-params alert]
-            (every? (partial matches-filter-param? filter-params alert) (keys filter-params)))]
-
-    (filter #(matches-filter-params? filter-params %) alerts)))
-
+  (filter #(matches-filter-params? filter-params %) alerts))
 
 (defn parse-alerts [filter-params, alerts-json]
   (reduce parse-alert


### PR DESCRIPTION
This was originally inlined using a `(letfn [..] ..)` block as two
functions: `matches-filter-param?` and `matches-filter-params?`.

Pull this out into a separate multi-arity function to make it easier
to read.
